### PR TITLE
Deploy to GitHub Pages using SSH as the deploy key is allowed now

### DIFF
--- a/ci/gh-pages.sh
+++ b/ci/gh-pages.sh
@@ -2,7 +2,7 @@
 set -x
 HASH=$(git rev-parse HEAD)
 mv -f assets tmp
-git remote add upstream https://github.com/ManageIQ/font-fabulous.git
+git remote add upstream git@github.com:ManageIQ/font-fabulous.git
 git fetch upstream
 git checkout upstream/gh-pages
 mv -f preview.html index.html
@@ -10,6 +10,5 @@ rm -rf assets
 mv -f tmp assets
 git add index.html assets/fonts assets/stylesheets
 git commit -m "GitHub pages build from ${HASH}"
+git push upstream HEAD:gh-pages &> /dev/null
 set +x
-echo "git push origin HEAD:gh-pages"
-git push https://$GITHUB_AUTH@github.com/ManageIQ/font-fabulous.git HEAD:gh-pages &> /dev/null


### PR DESCRIPTION
https://docs.travis-ci.com/user/encryption-keys/#Fetching-the-public-key-for-your-repository