### PR TITLE
cleanup .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: trusty
-sudo: false
 language: ruby
 addons:
   apt:

--- a/font-fabulous.gemspec
+++ b/font-fabulous.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files -- spec/*`.split("\n")
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.13'
+  spec.add_development_dependency 'bundler', '~> 2.1.4'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'fontcustom', '~> 2.0.0'
 end


### PR DESCRIPTION
`sudo: false` isn't needed per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

also, remove the distro listing, no idea why it's not the default, but Jason said I could, and bump bundler version to match core to get this to pass (or so we shall hope)