### PR TITLE
Ensure git name and email are set for deploy

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,5 +1,11 @@
 #!/bin/bash
 set -x
+
+if [ -n "$CI" ]; then
+  git config --global user.email "bot@manageiq.org"
+  git config --global user.name "ManageIQ Bot"
+fi
+
 SHA=$(git rev-parse HEAD)
 mv -f assets tmp
 git remote add upstream https://github.com/ManageIQ/font-fabulous.git


### PR DESCRIPTION
Follow up to #70 , which failed because on GitHub Actions, the git name and email are not set by default.